### PR TITLE
Clear the mechanical preen findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.22
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,7 +210,7 @@ html_static_path = ["_static"]
 
 # Generate GitHub Pages URL from repository URL
 if "github.com" in repository_url:
-    # Convert https://github.com/user/repo to https://user.github.io/repo/
+    # Convert github.com/<owner>/<name> to <owner>.github.io/<name>/
     repo_parts = repository_url.replace("https://github.com/", "").split("/")
     if len(repo_parts) >= 2:
         html_baseurl = f"https://{repo_parts[0]}.github.io/{repo_parts[1]}/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,12 @@ authors = [
   { name = "Suriyan", email = "suriyant@gmail.com" },
   { name = "Gaurav Sood", email = "gsood07@gmail.com" }
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -187,3 +187,10 @@ DEP001 = ["docs/source/examples/"]  # Allow missing dependencies in documentatio
 DEP002 = ["scikit-learn"]  # scikit-learn is needed for model compatibility (joblib files)
 DEP003 = ["docs/source/examples/"]  # Allow transitive dependencies in documentation examples
 DEP004 = ["tests/test_input_edge_cases.py", "tests/test_validation.py"]  # Allow test dependencies in test files
+
+[tool.codespell]
+# The census tables are surnames, not prose. codespell reported 1,800 findings
+# here, essentially all of them real names it mistook for misspellings, which
+# drowned the handful of genuine typos in the source. Auto-"correcting" a name
+# would also silently corrupt the data these models are trained on.
+skip = "*.csv,*.parquet,*.joblib,./ethnicolr2/data,./docs/build,./.venv,uv.lock"

--- a/uv.lock
+++ b/uv.lock
@@ -1889,11 +1889,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Takes `preen check --strict` from **12 gating findings to 5**.

| change | effect |
|---|---|
| `[tool.codespell] skip` for data dirs | 1,800 findings → 0 |
| license → PEP 639 form, drop `License ::` classifier | 2 → 0 |
| add the `.pre-commit-config.yaml` the template ships | 1 → 0 |
| pygments 2.19.2 → 2.20.0 (PYSEC-2026-2987) | 1 → 0 |
| reword two example URLs in a `conf.py` comment | 2 → 0 |

**On codespell:** the census tables are surnames, not prose, so codespell read essentially every name as a misspelling — drowning the handful of genuine typos in the source. Skipping the data directories is also the safer default: auto-"correcting" a name would silently corrupt the data these models are trained on.

**On the comment URLs:** `# Convert https://github.com/user/repo to https://user.github.io/repo/` was being fetched and 404'd. It was illustrating a conversion, not linking anywhere. Now `<owner>/<name>`, which reads better regardless.

## Deliberately left

- **`template: No .copier-answers.yml`** — adopting the template is a decision about this repo, not a lint fix.
- **`deptree: Circular import` ×2** — real, but restructuring package imports deserves its own change rather than riding along with metadata edits.
- **Five broken model-download URLs** — *not* noise. See the issue I filed: the `models` release they point at does not exist, so the package cannot fetch its own weights.

## Verification

`ruff check`, `ruff format --check`, **122 tests pass**.

Part of a fleet-wide conformance pass from gojiplus/py-canon.