### PR TITLE
Put ethnicolr2 in maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Put `ethnicolr2` in maintenance mode and direct new models and features to
+  `ethnicolr`.
+
 ## [0.3.3] - 2026-08-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,35 +6,29 @@
 [![image](https://static.pepy.tech/badge/ethnicolr2)](https://pepy.tech/project/ethnicolr2)
 [![Documentation](https://img.shields.io/badge/docs-github.io-blue)](https://appeler.github.io/ethnicolr2/)
 
-A Pytorch implementation of
-[ethnicolr](https://github.com/appeler/ethnicolr) with new models that
-make different assumptions (for instance, this package has models
-trained on unique names) than ethnicolr. The package uses the US census
-data and the Florida voting registration data to build models to predict
-the race and ethnicity (non-Hispanic whites, non-Hispanic Blacks,
-Asians, Hispanics, and Other) based on first and last name or just the
-last name. For notebooks underlying the package, see
-[here](https://github.com/appeler/ethnicolr_v2).
+## Project status
+
+`ethnicolr2` is in maintenance mode. Existing users can keep using it, and we
+will continue to fix serious bugs, security issues, and compatibility breaks.
+New projects should use [ethnicolr](https://github.com/appeler/ethnicolr), the
+canonical package. New models and features will be developed there.
+
+`ethnicolr2` preserves three PyTorch LSTM models trained on US Census and
+Florida voter registration data. The models predict five race and ethnicity
+categories from a last name or from a first and last name.
 
 # Caveats and Notes
 
-If you picked a random person with the last name \'Smith\' in the US in
-2010 and asked us to guess this person\'s race (as measured by the
-census), the best guess is the modal race of the person named Smith
-(which you can get from the census popular last name data file). It is
-the Bayes Optimal Solution. So what good are predictive models? A few
-things\-\--if you want to impute race and ethnicity for last names that
-are not in the census file, which can be because of errors, infer the
-race and ethnicity in different years than when the census was conducted
-(if some assumptions hold), infer the race of people in different
-countries (if some assumptions hold), etc. The biggest benefit comes in
-cases where both the first and last name are known.
+For a random person named Smith in the 2010 US Census population, the modal
+race among people named Smith is the Bayes-optimal point prediction. A model is
+most useful when a name is missing from the Census table or when both first and
+last names are available. Predictions outside the model's training population
+require assumptions that may not hold.
 
 # Install
 
-We strongly recommend installing [ethnicolor2]{.title-ref} inside a
-Python virtual environment (see [venv
-documentation](https://docs.python.org/3/library/venv.html#creating-virtual-environments))
+Install `ethnicolr2` inside a Python virtual environment (see the [venv
+documentation](https://docs.python.org/3/library/venv.html#creating-virtual-environments)).
 
     pip install ethnicolr2
 
@@ -66,17 +60,6 @@ Rajashekar Chintalapati, Suriyan Laohaprapanon, and Gaurav Sood
 
 # Contributor Code of Conduct
 
-The project welcomes contributions from everyone! In fact, it depends on
-it. To maintain this welcoming atmosphere and to collaborate in a fun
-and productive way, we expect contributors to the project to abide by
-the [Contributor Code of
+The project welcomes contributions from everyone. To maintain a welcoming
+atmosphere, contributors must abide by the [Contributor Code of
 Conduct](http://contributor-covenant.org/version/1/0/0/).
-
-
-## 🔗 Adjacent Repositories
-
-- [appeler/ethnicolr](https://github.com/appeler/ethnicolr) — Predict Race and Ethnicity Based on the Sequence of Characters in a Name
-- [appeler/ethnicolor](https://github.com/appeler/ethnicolor) — Race and Ethnicity based on name using data from census, voter reg. files, etc.
-- [appeler/parsernaam](https://github.com/appeler/parsernaam) — AI name parsing. Predict first or last name using a DL model.
-- [appeler/instate](https://github.com/appeler/instate) — instate: predict the state of residence from last name using the indian electoral rolls
-- [appeler/naamkaran](https://github.com/appeler/naamkaran) — generative model for names

--- a/docs/source/development/contributing.md
+++ b/docs/source/development/contributing.md
@@ -1,306 +1,48 @@
 # Contributing to ethnicolr2
 
-We welcome contributions to ethnicolr2! This guide will help you get started with contributing code, documentation, or reporting issues.
+`ethnicolr2` accepts maintenance changes for correctness, security,
+compatibility, packaging, tests, and documentation. Propose new models and
+features in [ethnicolr](https://github.com/appeler/ethnicolr), the canonical
+package.
 
-## Development Setup
+## Report a bug
 
-### Prerequisites
+Open a GitHub issue with:
 
-- Python 3.11 or higher
-- [uv](https://docs.astral.sh/uv/) (recommended) or pip
-- Git
+1. The `ethnicolr2`, Python, and operating system versions.
+2. The smallest example that reproduces the problem.
+3. The expected and actual results.
+4. The complete traceback, if one exists.
 
-### Clone and Setup
+Model-output reports should include the input rows, selected name columns, and
+the function called. Remove personal data before posting an example.
+
+## Develop locally
+
+Clone the repository and install every development group with
+[uv](https://docs.astral.sh/uv/):
 
 ```bash
-# Clone the repository
 git clone https://github.com/appeler/ethnicolr2.git
 cd ethnicolr2
-
-# Install development dependencies with uv (recommended)
 uv sync --all-groups
-
-# Or with pip
-pip install -e ".[dev,test,docs]"
 ```
 
-### Development Environment
+Create a focused branch for the fix. Include a regression test that fails
+without the fix and passes with it. Do not add new model families or change the
+pinned checkpoints unless the pull request fixes a documented model defect and
+includes reproducible validation.
+
+Run the complete local checks before opening a pull request:
 
 ```bash
-# Activate the virtual environment (if using uv)
-source .venv/bin/activate  # Linux/macOS
-# .venv\\Scripts\\activate     # Windows
-
-# Verify installation
-python -c "import ethnicolr2; print(ethnicolr2.__version__)"
-```
-
-## Development Workflow
-
-### 1. Create a Branch
-
-```bash
-git checkout -b feature/your-feature-name
-# or
-git checkout -b bugfix/issue-number
-```
-
-### 2. Make Changes
-
-Follow these guidelines:
-- Write clear, well-documented code
-- Add type hints to all functions
-- Follow existing code style
-- Add tests for new functionality
-
-### 3. Code Quality
-
-```bash
-# Format code with ruff
-uv run ruff format .
-
-# Check for linting issues
 uv run ruff check .
-
-# Fix auto-fixable issues
-uv run ruff check --fix .
-```
-
-### 4. Run Tests
-
-```bash
-# Run all tests
+uv run ruff format --check .
+uv run pyright
+uv run pydoclint src/ethnicolr2
 uv run pytest
-
-# Run with coverage
-uv run pytest --cov=ethnicolr2 --cov-report=term-missing
-
-# Run specific test file
-uv run pytest tests/test_models.py
+uv run sphinx-build -W -b html docs/source docs/build/html
 ```
 
-### 5. Documentation
-
-If you're changing APIs or adding features:
-
-```bash
-# Build documentation locally
-cd docs && uv run make html
-
-# View documentation
-open docs/build/html/index.html  # macOS
-# xdg-open docs/build/html/index.html  # Linux
-```
-
-### 6. Commit Changes
-
-```bash
-git add .
-git commit -m "feat: add new feature description
-
-- Detailed explanation of changes
-- Any breaking changes
-- Resolves #issue-number"
-```
-
-## Contribution Types
-
-### Bug Reports
-
-When reporting bugs, please include:
-
-1. **Environment**: OS, Python version, ethnicolr2 version
-2. **Minimal example**: Smallest code that reproduces the issue
-3. **Expected vs actual behavior**
-4. **Error messages** (full traceback if applicable)
-
-**Template:**
-```markdown
-## Bug Report
-
-**Environment:**
-- OS: macOS 14.0
-- Python: 3.11.5
-- ethnicolr2: 0.2.0
-
-**Code to reproduce:**
-\\```python
-import ethnicolr2
-# Minimal example here
-\\```
-
-**Expected:** Description of expected behavior
-**Actual:** Description of what actually happened
-**Error:** Full error message if applicable
-```
-
-### Feature Requests
-
-For new features, please include:
-
-1. **Use case**: Why is this feature needed?
-2. **Proposed API**: How should it work?
-3. **Examples**: Show usage examples
-4. **Alternatives**: Have you considered other approaches?
-
-### Code Contributions
-
-#### Adding New Models
-
-If adding a new prediction model:
-
-1. Create model class in appropriate module
-2. Follow naming convention: `{Dataset}{Type}Model`
-3. Inherit from `EthnicolrModelClass`
-4. Add comprehensive tests
-5. Update documentation
-
-Example structure:
-```python
-from .ethnicolr_class import EthnicolrModelClass
-
-class NewDatasetLstmModel(EthnicolrModelClass):
-    \"\"\"LSTM model trained on new dataset.\"\"\"
-
-    MAX_SEQUENCE_LENGTH = 30
-    VOCAB_FN = "new_vocab.joblib"
-    MODEL_FN = "new_model.pt"
-
-    @classmethod
-    def predict(cls, df, **kwargs):
-        # Implementation
-        pass
-```
-
-#### Adding New Features
-
-For new features:
-1. Add function to appropriate module
-2. Include comprehensive docstring
-3. Add type hints
-4. Write tests covering edge cases
-5. Update documentation
-
-### Documentation Contributions
-
-Documentation improvements are always welcome:
-
-- **Fix typos** or unclear explanations
-- **Add examples** for existing features
-- **Improve API documentation**
-- **Update guides** for new best practices
-
-```bash
-# Test documentation changes locally
-cd docs
-uv run make clean html
-open build/html/index.html
-```
-
-## Code Style Guide
-
-### Python Style
-
-We use [Ruff](https://docs.astral.sh/ruff/) for code formatting and linting:
-
-- **Line length**: 88 characters (Black-compatible)
-- **Import sorting**: isort-compatible
-- **Type hints**: Required for all public functions
-- **Docstrings**: Google-style docstrings
-
-### Docstring Format
-
-```python
-def example_function(name: str, threshold: float = 0.5) -> pd.DataFrame:
-    \"\"\"Predict something from name.
-
-    Args:
-        name: The input name to process.
-        threshold: Confidence threshold for predictions.
-
-    Returns:
-        DataFrame with predictions and confidence scores.
-
-    Raises:
-        ValueError: If threshold is not between 0 and 1.
-        KeyError: If required columns are missing.
-
-    Examples:
-        >>> df = pd.DataFrame({'names': ['Smith', 'Zhang']})
-        >>> result = example_function(df, threshold=0.8)
-        >>> print(result.columns)
-        ['names', 'race', 'confidence']
-    \"\"\"
-```
-
-### Testing Guidelines
-
-- **Test coverage**: Aim for >90% coverage
-- **Test structure**: Use pytest fixtures for common setup
-- **Test data**: Use small, predictable datasets
-- **Edge cases**: Test empty inputs, missing columns, etc.
-
-```python
-def test_prediction_function():
-    \"\"\"Test basic prediction functionality.\"\"\"
-    # Arrange
-    df = pd.DataFrame({'last_name': ['Smith', 'Zhang']})
-
-    # Act
-    result = pred_fl_last_name(df, lname_col='last_name')
-
-    # Assert
-    assert len(result) == 2
-    assert 'race' in result.columns
-    assert result['race'].isin(['asian', 'hispanic', 'nh_black', 'nh_white']).all()
-```
-
-## Release Process
-
-### Version Bumping
-
-We use semantic versioning (MAJOR.MINOR.PATCH):
-
-- **MAJOR**: Breaking changes
-- **MINOR**: New features (backward compatible)
-- **PATCH**: Bug fixes
-
-```bash
-# Update version in pyproject.toml
-# Update CHANGELOG.md
-# Create release commit
-git commit -m "release: version 0.2.1"
-git tag v0.2.1
-git push origin main --tags
-```
-
-### Changelog
-
-Update `CHANGELOG.md` with:
-- **Breaking changes** (if any)
-- **New features**
-- **Bug fixes**
-- **Technical improvements**
-
-## Getting Help
-
-### Development Questions
-
-- **GitHub Discussions**: General development questions
-- **GitHub Issues**: Bug reports and feature requests
-- **Code Review**: Submit PRs for feedback
-
-### Resources
-
-- **Project Structure**: See {doc}`../getting-started/concepts`
-- **API Documentation**: See {doc}`../api-reference/index`
-- **Testing Guide**: See {doc}`testing`
-
-## Recognition
-
-Contributors are recognized in:
-- `CONTRIBUTORS.md` file
-- GitHub contributor list
-- Release notes for significant contributions
-
-Thank you for contributing to ethnicolr2! 🎉
+Pull requests should explain the defect, the fix, and the evidence that the fix
+works. Keep unrelated cleanup out of the same change.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,17 +5,28 @@
 ![Python Version](https://img.shields.io/pypi/pyversions/ethnicolr2.svg)
 ![Downloads](https://pepy.tech/badge/ethnicolr2)
 
-**ethnicolr2** is a modern PyTorch-based machine learning package that predicts race and ethnicity from names using LSTM neural networks. It's trained on US Census data and Florida voter registration data to provide accurate predictions based on:
+## Project status
+
+`ethnicolr2` is in maintenance mode. Existing users can keep using it, and we
+will continue to fix serious bugs, security issues, and compatibility breaks.
+New projects should use [ethnicolr](https://github.com/appeler/ethnicolr), the
+canonical package. New models and features will be developed there.
+
+`ethnicolr2` preserves three PyTorch LSTM models trained on US Census and
+Florida voter registration data. The models use:
 
 - **Last name only** (census model or Florida model)
 - **First and last name combined** (Florida full name model)
 
-## Quick Start
+## Quick start for existing projects
 
 ```bash
-# Install ethnicolr2
 uv add ethnicolr2
-# or
+```
+
+or
+
+```bash
 pip install ethnicolr2
 ```
 


### PR DESCRIPTION
States that ethnicolr2 remains supported for serious maintenance fixes while ethnicolr is the canonical package for new projects, models, and features. Replaces the contributor guide's feature-development instructions with a focused maintenance workflow and removes the stale adjacent-repository list.

Local verification: Ruff lint and format, Pyright, pydoclint, 129 tests, and Sphinx with warnings as errors.