### PR TITLE
Cite the version this package actually is

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,6 @@ authors:
 - family-names: "Sood"
   given-names: "Gaurav"
 title: "ethnicolr2: Predict Race and Ethnicity From Name"
-version: 0.1.1
-date-released: 2023-08-17
+version: 0.3.3
+date-released: 2026-08-16
 url: "https://github.com/appeler/ethnicolr2"


### PR DESCRIPTION
`CITATION.cff` recorded version `0.1.1`; `project.version` is `0.3.3`. Whoever cites this package copies that number, so a stale one outlives the release in someone else's bibliography.


Found by `preen check` sweeping the fleet — this repo was one of eight — and applied with `preen fix citation`, which also moves `date-released` to the date of the tag naming the release rather than leaving a right version beside a wrong date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX