### PR TITLE
Stop a reachable census.gov page from failing CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,3 +157,12 @@ DEP004 = ["tests/test_input_edge_cases.py", "tests/test_validation.py"]  # Allow
 # drowned the handful of genuine typos in the source. Auto-"correcting" a name
 # would also silently corrupt the data these models are trained on.
 skip = "*.csv,*.parquet,*.joblib,./src/ethnicolr2/data,./docs/build,./.venv,uv.lock"
+
+[tool.preen]
+link_ignore = [
+    # Alive, but not from a GitHub runner. Both surname tables answer 200 from
+    # a workstation; from Actions egress the request fails, and it has been
+    # failing CI on main since 2026-08-24 for a page that has not moved. The
+    # README that cites them is the right place for those citations.
+    "census\\.gov/topics/population/genealogy/",
+]


### PR DESCRIPTION
`preen check --strict` has been failing on `main` since **2026-08-24**, for a link that is not broken.

`model_training/data/census/README.md` cites the Census Bureau's 2000 and 2010 surname tables — the whole subject of that README. Both answer 200 from a workstation:

```
https://www.census.gov/topics/population/genealogy/data/2000_surnames.html  200
https://www.census.gov/topics/population/genealogy/data/2010_surnames.html  200
```

From GitHub Actions egress the request fails. The page has not moved and the citation is correct; the runner just cannot reach it.

`[tool.preen] link_ignore` is the escape hatch for exactly this — an endpoint that is alive but does not answer a bare GET from CI. The host goes there rather than the citations being dropped from a README that exists to point at them.

Verified: `LinkCheck` on this branch reports `passed, 0 issues`.

Same class of problem as gojiplus/py-canon#66, which had `scientific-python.org` blocking every PR in that repo — there, a rerun of the *same commit* failed on a different URL of the same host, which is what identifies it as egress rather than a dead page.

Noting this also unblocks #41, which is a one-line CITATION.cff fix that inherited this red main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX